### PR TITLE
remove exception on label starting with number

### DIFF
--- a/src/Utilities/HostValidator.php
+++ b/src/Utilities/HostValidator.php
@@ -190,7 +190,7 @@ trait HostValidator
     protected function assertValidHost(array $labels)
     {
         $verifs = array_filter($labels, function ($value) {
-            return ! empty($value) && ! preg_match('/^[0-9]+$/', $value);
+            return ! empty($value);
         });
 
         if ($verifs != $labels) {


### PR DESCRIPTION
labels may start with numbers (or be entirely numbers) as per rfc1123 (ref: http://tools.ietf.org/html/rfc1123#page-13)
